### PR TITLE
Refactor execution times & tree tracking

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -2,6 +2,7 @@ services:
   Neusta\Pimcore\FixtureBundle\Command\LoadFixturesCommand:
     arguments:
       $container: '@Symfony\Component\DependencyInjection\ContainerInterface'
+      $eventDispatcher: '@event_dispatcher'
       $fixtureClass: !abstract defined in extension
     tags:
       - { name: 'console.command' }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,31 +6,6 @@ parameters:
 			path: src/Command/LoadFixturesCommand.php
 
 		-
-			message: "#^Offset 'fixtureClass' does not exist on array\\<class\\-string, int\\>\\.$#"
-			count: 1
-			path: src/Command/LoadFixturesCommand.php
-
-		-
-			message: "#^Offset 'level' does not exist on array\\<class\\-string, int\\>\\.$#"
-			count: 1
-			path: src/Command/LoadFixturesCommand.php
-
-		-
-			message: "#^Property Neusta\\\\Pimcore\\\\FixtureBundle\\\\Factory\\\\FixtureFactory\\:\\:\\$executionTimes \\(array\\<class\\-string, float\\>\\) does not accept array\\<string, float\\|int\\>\\.$#"
-			count: 1
-			path: src/Factory/FixtureFactory.php
-
-		-
-			message: "#^Property Neusta\\\\Pimcore\\\\FixtureBundle\\\\Factory\\\\FixtureFactory\\:\\:\\$executionTree \\(array\\<array\\<class\\-string, int\\>\\>\\) does not accept array\\<array\\<string, class\\-string\\<Neusta\\\\Pimcore\\\\FixtureBundle\\\\Fixture\\>\\|int\\>\\>\\.$#"
-			count: 1
-			path: src/Factory/FixtureFactory.php
-
-		-
-			message: "#^Variable \\$start might not be defined\\.$#"
-			count: 1
-			path: src/Factory/FixtureFactory.php
-
-		-
 			message: "#^Method Neusta\\\\Pimcore\\\\FixtureBundle\\\\Helper\\\\AssetHelper\\:\\:createAssetFolder\\(\\) should return Pimcore\\\\Model\\\\Asset\\\\Folder but returns Pimcore\\\\Model\\\\Asset\\\\Folder\\|Pimcore\\\\Model\\\\DataObject\\\\Folder\\|Pimcore\\\\Model\\\\Document\\\\Folder\\.$#"
 			count: 1
 			path: src/Helper/AssetHelper.php

--- a/src/Event/CreateFixture.php
+++ b/src/Event/CreateFixture.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\FixtureBundle\Event;
+
+final class CreateFixture
+{
+    /**
+     * @param class-string $class
+     */
+    public function __construct(
+        public readonly string $class,
+        public readonly int $level,
+    ) {
+    }
+}

--- a/src/Event/FixtureWasCreated.php
+++ b/src/Event/FixtureWasCreated.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\FixtureBundle\Event;
+
+use Neusta\Pimcore\FixtureBundle\Fixture;
+
+final class FixtureWasCreated
+{
+    public function __construct(
+        public readonly Fixture $fixture,
+    ) {
+    }
+}

--- a/src/EventListener/ExecutionTimesListener.php
+++ b/src/EventListener/ExecutionTimesListener.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\FixtureBundle\EventListener;
+
+use Neusta\Pimcore\FixtureBundle\Event\CreateFixture;
+use Neusta\Pimcore\FixtureBundle\Event\FixtureWasCreated;
+
+final class ExecutionTimesListener
+{
+    /** @var array<string, float> */
+    private array $executionTimes = [];
+    private float $currentTime;
+
+    public function onCreateFixture(CreateFixture $event): void
+    {
+        $this->currentTime = microtime(true);
+    }
+
+    public function onFixtureWasCreated(FixtureWasCreated $event): void
+    {
+        $this->executionTimes[$event->fixture::class] = microtime(true) - $this->currentTime;
+    }
+
+    /**
+     * @return array<string, float>
+     */
+    public function getExecutionTimes(): array
+    {
+        return $this->executionTimes;
+    }
+
+    public function getTotalTime(): float
+    {
+        return array_sum($this->executionTimes);
+    }
+}

--- a/src/EventListener/ExecutionTreeListener.php
+++ b/src/EventListener/ExecutionTreeListener.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\FixtureBundle\EventListener;
+
+use Neusta\Pimcore\FixtureBundle\Event\CreateFixture;
+
+final class ExecutionTreeListener
+{
+    /** @var list<array{fixtureClass: class-string, level: int}> */
+    private array $executionTree = [];
+
+    public function onCreateFixture(CreateFixture $event): void
+    {
+        $this->executionTree[] = ['fixtureClass' => $event->class, 'level' => $event->level];
+    }
+
+    /**
+     * @return list<array{fixtureClass: class-string, level: int}>
+     */
+    public function getExecutionTree(): array
+    {
+        return $this->executionTree;
+    }
+}


### PR DESCRIPTION
This adds the `CreateFixture` and `FixtureWasCreated` events that are dispatched before and after a fixture was created, which allows, e.g., tracking the execution times.