### PR TITLE
Remove the possibility of mapping fixtures

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,11 +21,6 @@ parameters:
 			path: src/Factory/FixtureFactory.php
 
 		-
-			message: "#^Property Neusta\\\\Pimcore\\\\FixtureBundle\\\\Factory\\\\FixtureFactory\\:\\:\\$executionTimes \\(array\\<class\\-string, float\\>\\) does not accept array\\<string, float\\>\\.$#"
-			count: 1
-			path: src/Factory/FixtureFactory.php
-
-		-
 			message: "#^Property Neusta\\\\Pimcore\\\\FixtureBundle\\\\Factory\\\\FixtureFactory\\:\\:\\$executionTimes \\(array\\<class\\-string, float\\>\\) does not accept array\\<string, float\\|int\\>\\.$#"
 			count: 1
 			path: src/Factory/FixtureFactory.php

--- a/src/Command/LoadFixturesCommand.php
+++ b/src/Command/LoadFixturesCommand.php
@@ -5,6 +5,7 @@ namespace Neusta\Pimcore\FixtureBundle\Command;
 use Neusta\Pimcore\FixtureBundle\Factory\FixtureFactory;
 use Neusta\Pimcore\FixtureBundle\Factory\FixtureInstantiator\FixtureInstantiatorForAll;
 use Neusta\Pimcore\FixtureBundle\Factory\FixtureInstantiator\FixtureInstantiatorForParametrizedConstructors;
+use Neusta\Pimcore\FixtureBundle\Fixture;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
@@ -20,6 +21,9 @@ class LoadFixturesCommand extends Command
 {
     private OutputInterface $output;
 
+    /**
+     * @param class-string<Fixture> $fixtureClass
+     */
     public function __construct(
         private ContainerInterface $container,
         private string $fixtureClass,
@@ -64,7 +68,7 @@ class LoadFixturesCommand extends Command
         ];
 
         $trackExecutionTimes = OutputInterface::VERBOSITY_VERBOSE === $this->output->getVerbosity();
-        $fixtureFactory = new FixtureFactory([], $instantiators, $trackExecutionTimes);
+        $fixtureFactory = new FixtureFactory($instantiators, $trackExecutionTimes);
         $fixtureFactory->createFixtures([$this->fixtureClass]);
 
         if (OutputInterface::VERBOSITY_VERBOSE === $this->output->getVerbosity()) {

--- a/src/Factory/FixtureFactory.php
+++ b/src/Factory/FixtureFactory.php
@@ -17,11 +17,9 @@ class FixtureFactory
     private array $executionTree = [];
 
     /**
-     * @param array<string, class-string<Fixture>> $fixtureMapping
-     * @param list<FixtureInstantiator>            $instantiators
+     * @param list<FixtureInstantiator> $instantiators
      */
     public function __construct(
-        private array $fixtureMapping,
         private array $instantiators,
         private bool $trackExecutionTime = false,
     ) {
@@ -44,7 +42,7 @@ class FixtureFactory
     }
 
     /**
-     * @param list<string|class-string<Fixture>> $fixtures
+     * @param list<class-string<Fixture>> $fixtures
      */
     public function createFixtures(array $fixtures): void
     {
@@ -53,16 +51,16 @@ class FixtureFactory
         Version::disable();
         Cache::disable();
 
-        foreach ($fixtures as $fixtureNameOrClass) {
+        foreach ($fixtures as $fixtureClass) {
             if ($this->trackExecutionTime) {
                 $start = microtime(true);
             }
 
-            $this->ensureIsFixture($fixtureClass = $this->fixtureMapping[$fixtureNameOrClass] ?? $fixtureNameOrClass);
+            $this->ensureIsFixture($fixtureClass);
             $this->createFixture($fixtureClass, 0);
 
             if ($this->trackExecutionTime) {
-                $this->executionTimes[$fixtureNameOrClass] = microtime(true) - $start;
+                $this->executionTimes[$fixtureClass] = microtime(true) - $start;
             }
         }
 

--- a/tests/Functional/Factory/FixtureFactoryTest.php
+++ b/tests/Functional/Factory/FixtureFactoryTest.php
@@ -22,7 +22,7 @@ final class FixtureFactoryTest extends KernelTestCase
      */
     public function it_creates_a_fixture(): void
     {
-        $factory = new FixtureFactory([], [new FixtureInstantiatorForAll()]);
+        $factory = new FixtureFactory([new FixtureInstantiatorForAll()]);
 
         $factory->createFixtures([SomeFixture::class]);
 
@@ -34,23 +34,9 @@ final class FixtureFactoryTest extends KernelTestCase
     /**
      * @test
      */
-    public function it_creates_a_fixture_from_a_mapped_name(): void
-    {
-        $factory = new FixtureFactory(['something' => SomeFixture::class], [new FixtureInstantiatorForAll()]);
-
-        $factory->createFixtures(['something']);
-
-        $fixture = $factory->getFixture(SomeFixture::class);
-        self::assertInstanceOf(SomeFixture::class, $fixture);
-        self::assertTrue($fixture->created);
-    }
-
-    /**
-     * @test
-     */
     public function it_throws_when_prompted_to_create_a_fixture_that_does_not_implement_the_Fixture_interface(): void
     {
-        $factory = new FixtureFactory([], [new FixtureInstantiatorForAll()]);
+        $factory = new FixtureFactory([new FixtureInstantiatorForAll()]);
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected "stdClass" to implement "Neusta\Pimcore\FixtureBundle\Fixture", but it does not.');
@@ -63,7 +49,7 @@ final class FixtureFactoryTest extends KernelTestCase
      */
     public function it_creates_depending_fixtures_first(): void
     {
-        $factory = new FixtureFactory([], [new FixtureInstantiatorForAll()]);
+        $factory = new FixtureFactory([new FixtureInstantiatorForAll()]);
 
         $factory->createFixtures([FixtureWithDependency::class]);
 
@@ -79,7 +65,7 @@ final class FixtureFactoryTest extends KernelTestCase
      */
     public function it_throws_when_dependency_has_invalid_type(): void
     {
-        $factory = new FixtureFactory([], [new FixtureInstantiatorForAll()]);
+        $factory = new FixtureFactory([new FixtureInstantiatorForAll()]);
         $fixture = new class() implements Fixture {
             public function create($something): void
             {
@@ -97,7 +83,7 @@ final class FixtureFactoryTest extends KernelTestCase
      */
     public function it_throws_when_depending_on_a_non_fixture_object(): void
     {
-        $factory = new FixtureFactory([], [new FixtureInstantiatorForAll()]);
+        $factory = new FixtureFactory([new FixtureInstantiatorForAll()]);
         $fixture = new class() implements Fixture {
             public function create(\stdClass $noFixture): void
             {
@@ -115,7 +101,7 @@ final class FixtureFactoryTest extends KernelTestCase
      */
     public function it_creates_a_fixture_only_once(): void
     {
-        $factory = new FixtureFactory([], [new FixtureInstantiatorForAll()]);
+        $factory = new FixtureFactory([new FixtureInstantiatorForAll()]);
 
         $factory->createFixtures([FixtureWithDependency::class]);
 


### PR DESCRIPTION
I don't think we should support this by default. It's not really necessary, and it's better to reference the fixtures by their class name.