### PR TITLE
Mention loading fixtures via symfony console command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ setting the environment to `prod`. Disabling the debug mode also seems to be ben
 For example provide these options when using the symfony console: 
 ```shell
 bin/console --env=prod --no-debug neusta:pimcore-fixtures:load
-
+```
 
 ### Accessing Services from the Fixtures
 

--- a/README.md
+++ b/README.md
@@ -187,9 +187,8 @@ Should you encounter memory issues when running the commands in `dev` environmen
 setting the environment to `prod`. Disabling the debug mode also seems to be beneficial in terms of memory consumption. 
 
 For example provide these options when using the symfony console: 
-```
-console --env=prod --no-debug neusta:pimcore-fixtures:load
-```
+```shell
+bin/console --env=prod --no-debug neusta:pimcore-fixtures:load
 
 
 ### Accessing Services from the Fixtures

--- a/README.md
+++ b/README.md
@@ -178,6 +178,14 @@ final class MyCustomTest extends BaseKernelTestCase
 }
 ```
 
+To load fixtures in your local environment or as part of a deployment two commands are provided:
+- `neusta:pimcore-fixture:load` (Loads a defined fixture class.)
+- `neusta:pimcore-fixtures:load` (Loads all defined fixture classes.)
+
+Beware that loading a large amount of objects may lead to a high consumption of memory.
+Should you encounter memory issues when running the commands in `dev` environments you may want to try
+setting the environment to `prod`. This appears to be beneficial in terms of pimcore's memory consumption. 
+
 ### Accessing Services from the Fixtures
 
 As the Fixtures are just normal PHP Services you can use all DI features like constructor, setter or property injection as usual.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,13 @@ To load fixtures in your local environment or as part of a deployment two comman
 
 Beware that loading a large amount of objects may lead to a high consumption of memory.
 Should you encounter memory issues when running the commands in `dev` environments you may want to try
-setting the environment to `prod`. This appears to be beneficial in terms of pimcore's memory consumption. 
+setting the environment to `prod`. Disabling the debug mode also seems to be beneficial in terms of memory consumption. 
+
+For example provide these options when using the symfony console: 
+```
+console --env=prod --no-debug neusta:pimcore-fixtures:load
+```
+
 
 ### Accessing Services from the Fixtures
 

--- a/src/EventListener/PimcoreLoadOptimization.php
+++ b/src/EventListener/PimcoreLoadOptimization.php
@@ -3,7 +3,6 @@
 namespace Neusta\Pimcore\FixtureBundle\EventListener;
 
 use Doctrine\DBAL\Logging\SQLLogger;
-use Neusta\Pimcore\FixtureBundle\Event\AfterExecuteFixture;
 use Neusta\Pimcore\FixtureBundle\Event\AfterLoadFixtures;
 use Neusta\Pimcore\FixtureBundle\Event\BeforeLoadFixtures;
 use Pimcore\Cache;
@@ -30,7 +29,6 @@ final class PimcoreLoadOptimization implements EventSubscriberInterface
         return [
             BeforeLoadFixtures::class => 'beforeCommand',
             AfterLoadFixtures::class => 'afterCommand',
-            AfterExecuteFixture::class => 'afterExecute',
         ];
     }
 
@@ -53,10 +51,5 @@ final class PimcoreLoadOptimization implements EventSubscriberInterface
 
         $this->versionEnabled && Version::enable();
         $this->cacheEnabled && Cache::enable();
-    }
-
-    public function afterExecute(): void
-    {
-        \Pimcore::collectGarbage();
     }
 }

--- a/src/EventListener/PimcoreLoadOptimization.php
+++ b/src/EventListener/PimcoreLoadOptimization.php
@@ -3,6 +3,7 @@
 namespace Neusta\Pimcore\FixtureBundle\EventListener;
 
 use Doctrine\DBAL\Logging\SQLLogger;
+use Neusta\Pimcore\FixtureBundle\Event\AfterExecuteFixture;
 use Neusta\Pimcore\FixtureBundle\Event\AfterLoadFixtures;
 use Neusta\Pimcore\FixtureBundle\Event\BeforeLoadFixtures;
 use Pimcore\Cache;
@@ -29,6 +30,7 @@ final class PimcoreLoadOptimization implements EventSubscriberInterface
         return [
             BeforeLoadFixtures::class => 'beforeCommand',
             AfterLoadFixtures::class => 'afterCommand',
+            AfterExecuteFixture::class => 'afterExecute',
         ];
     }
 
@@ -51,5 +53,10 @@ final class PimcoreLoadOptimization implements EventSubscriberInterface
 
         $this->versionEnabled && Version::enable();
         $this->cacheEnabled && Cache::enable();
+    }
+
+    public function afterExecute(): void
+    {
+        \Pimcore::collectGarbage();
     }
 }


### PR DESCRIPTION
Loading fixtures via console commands may lead to greater memory consumption especially when handling large numbers of objects. In order to regularly free memory when possible, trigger `Pimcore::collectGarbage()` after executing a fixture.

Also mention the provided console commands in README.md