### PR TITLE
Fix circular dependency detection in `FixtureDependencySorter`

### DIFF
--- a/src/Sorter/FixtureDependencySorter.php
+++ b/src/Sorter/FixtureDependencySorter.php
@@ -7,7 +7,7 @@ use Neusta\Pimcore\FixtureBundle\Fixture\HasDependencies;
 
 final class FixtureDependencySorter
 {
-    /** @var array<class-string<Fixture>> */
+    /** @var array<class-string<Fixture>, true> */
     private array $checking = [];
 
     /**
@@ -44,10 +44,11 @@ final class FixtureDependencySorter
             return;
         }
 
-        if (\in_array($fixture::class, $this->checking, true)) {
+        if (isset($this->checking[$fixture::class])) {
             throw new CircularFixtureDependency($fixture::class);
         }
-        $this->checking[] = $fixture::class;
+
+        $this->checking[$fixture::class] = true;
 
         if ($fixture instanceof HasDependencies) {
             foreach ($fixture->getDependencies() as $dependency) {
@@ -57,7 +58,7 @@ final class FixtureDependencySorter
 
         $sorted[] = $fixture;
 
-        $this->checking = array_filter($this->checking, fn ($v) => $v !== $fixture::class);
+        unset($this->checking[$fixture::class]);
     }
 
     private function getFixture(string $name): Fixture

--- a/src/Sorter/FixtureDependencySorter.php
+++ b/src/Sorter/FixtureDependencySorter.php
@@ -49,15 +49,12 @@ final class FixtureDependencySorter
         }
         $this->checking[] = $fixture::class;
 
-        if (!$fixture instanceof HasDependencies || [] === $fixture->getDependencies()) {
-            $sorted[] = $fixture;
-
-            return;
+        if ($fixture instanceof HasDependencies) {
+            foreach ($fixture->getDependencies() as $dependency) {
+                $this->add($this->getFixture($dependency), $sorted);
+            }
         }
 
-        foreach ($fixture->getDependencies() as $dependency) {
-            $this->add($this->getFixture($dependency), $sorted);
-        }
         $sorted[] = $fixture;
 
         $this->checking = array_filter($this->checking, fn ($v) => $v !== $fixture::class);


### PR DESCRIPTION
If a fixture had no dependencies, it was not removed from the `$checking` property.

Also, the circular dependency tracking is improved by using a map instead of a list.