### PR TITLE
Align parameter name

### DIFF
--- a/src/Fixture/AbstractFixture.php
+++ b/src/Fixture/AbstractFixture.php
@@ -24,9 +24,9 @@ abstract class AbstractFixture implements Fixture
     /**
      * @throws \BadMethodCallException - if repository already has a reference by $name
      */
-    protected function addReference(string $name, object $object): void
+    protected function addReference(string $name, object $reference): void
     {
-        $this->objectReferenceRepository->addReference($name, $object);
+        $this->objectReferenceRepository->addReference($name, $reference);
     }
 
     /**


### PR DESCRIPTION
Renames the second parameter of `\Neusta\Pimcore\FixtureBundle\Fixture\AbstractFixture::addReference()` to match the second one of `\Neusta\Pimcore\FixtureBundle\Fixture\AbstractFixture::setReference()`

Note that this is technically a BC break (if anyone here uses named parameters), but I'm not sure if we care... :thinking: 