### PR TITLE
Sort the fixtures at the end of the loading process

### DIFF
--- a/src/EventListener/SortFixturesByDependencyBeforeLoad.php
+++ b/src/EventListener/SortFixturesByDependencyBeforeLoad.php
@@ -16,7 +16,7 @@ final class SortFixturesByDependencyBeforeLoad implements EventSubscriberInterfa
     public static function getSubscribedEvents(): array
     {
         return [
-            BeforeLoadFixtures::class => 'sortFixturesByDependency',
+            BeforeLoadFixtures::class => ['sortFixturesByDependency', -100],
         ];
     }
 


### PR DESCRIPTION
If no explicit priority is specified, it will be `0`, which means that the sorter will run somewhere between all other (user-defined) listeners without priority. 

However, the sorting should only take place at the end, after possible manipulations of the fixtures in other listeners.