### PR TITLE
Refactor `FixtureDependencySorter`

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -44,6 +44,8 @@ services:
   Neusta\Pimcore\FixtureBundle\ReferenceRepository\:
     resource: '../src/ReferenceRepository/*'
 
+  Neusta\Pimcore\FixtureBundle\Sorter\FixtureDependencySorter: ~
+
 when@dev:
   services:
     Neusta\Pimcore\FixtureBundle\Profiler\:

--- a/src/EventListener/SortFixturesByDependencyBeforeLoad.php
+++ b/src/EventListener/SortFixturesByDependencyBeforeLoad.php
@@ -3,17 +3,13 @@
 namespace Neusta\Pimcore\FixtureBundle\EventListener;
 
 use Neusta\Pimcore\FixtureBundle\Event\BeforeLoadFixtures;
-use Neusta\Pimcore\FixtureBundle\Fixture\Fixture;
 use Neusta\Pimcore\FixtureBundle\Sorter\FixtureDependencySorter;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class SortFixturesByDependencyBeforeLoad implements EventSubscriberInterface
 {
-    /**
-     * @param \Traversable<Fixture> $allFixtures
-     */
     public function __construct(
-        private readonly \Traversable $allFixtures,
+        private readonly FixtureDependencySorter $dependencySorter,
     ) {
     }
 
@@ -26,7 +22,6 @@ final class SortFixturesByDependencyBeforeLoad implements EventSubscriberInterfa
 
     public function sortFixturesByDependency(BeforeLoadFixtures $event): void
     {
-        $event->fixtures = (new FixtureDependencySorter(iterator_to_array($this->allFixtures, false)))
-            ->sort($event->fixtures);
+        $event->fixtures = $this->dependencySorter->sort($event->fixtures);
     }
 }

--- a/src/Sorter/FixtureDependencySorter.php
+++ b/src/Sorter/FixtureDependencySorter.php
@@ -7,15 +7,23 @@ use Neusta\Pimcore\FixtureBundle\Fixture\HasDependencies;
 
 final class FixtureDependencySorter
 {
+    /** @var array<class-string<Fixture>, Fixture> */
+    private readonly array $allFixtures;
+
     /** @var array<class-string<Fixture>> */
     private array $checking = [];
 
     /**
-     * @param list<Fixture> $allFixtures
+     * @param iterable<Fixture> $allFixtures
      */
-    public function __construct(
-        private readonly array $allFixtures,
-    ) {
+    public function __construct(iterable $allFixtures)
+    {
+        $indexed = [];
+        foreach ($allFixtures as $fixture) {
+            $indexed[$fixture::class] = $fixture;
+        }
+
+        $this->allFixtures = $indexed;
     }
 
     /**
@@ -63,14 +71,11 @@ final class FixtureDependencySorter
         $this->checking = array_filter($this->checking, fn ($v) => $v !== $fixture::class);
     }
 
+    /**
+     * @param class-string<Fixture> $name
+     */
     private function getFixture(string $name): Fixture
     {
-        foreach ($this->allFixtures as $fixture) {
-            if ($fixture::class === $name) {
-                return $fixture;
-            }
-        }
-
-        throw new UnresolvedFixtureDependency($name);
+        return $this->allFixtures[$name] ?? throw new UnresolvedFixtureDependency($name);
     }
 }


### PR DESCRIPTION
It's more efficient this way, because we won't have to iterate the `allFixtures` property every time we search for a fixture.